### PR TITLE
Added Palindrome checker algorithm in Java

### DIFF
--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>


### PR DESCRIPTION
Refer to issue #449 

This Java program provides a straightforward way to check if a given string is a palindrome. It uses a two-pointer technique to compare characters from the beginning and end of the string, moving towards the center. If all corresponding characters match, the string is a palindrome; otherwise, it is not.