### PR TITLE
CSS Warning Fixed

### DIFF
--- a/contributors/Files/css/style.css
+++ b/contributors/Files/css/style.css
@@ -159,6 +159,7 @@ section .card h1 {
 	background-size: 350%;
   background-repeat: no-repeat;
   -webkit-background-clip: text;
+  background-clip: text;
   -webkit-text-fill-color: rgba(255, 255, 255, 0);
 }
 


### PR DESCRIPTION
Fixed a lint warning by adding the standard background-clip: text; property after the vendor-prefixed -webkit-background-clip: text;.This makes the CSS more compatible with different browsers and follows best practices. It also removes the warning from the IDE or linting tools.Now the code is cleaner, future-proof, and works better across browsers.

Refer to issue #477 